### PR TITLE
Adopt Sender.append() and flush()

### DIFF
--- a/jaeger_client/reporter.py
+++ b/jaeger_client/reporter.py
@@ -20,10 +20,8 @@ import threading
 import tornado.gen
 import tornado.ioloop
 import tornado.queues
-import socket
 from tornado.concurrent import Future
 from .constants import DEFAULT_FLUSH_INTERVAL
-from . import thrift
 from . import ioloop_util
 from .metrics import Metrics, LegacyMetricsFactory
 from .senders import UDPSender
@@ -122,9 +120,6 @@ class Reporter(NullReporter):
             self.flush_interval = flush_interval or None
             self.io_loop.spawn_callback(self._consume_queue)
 
-        self._process_lock = Lock()
-        self._process = None
-
     @staticmethod
     def fetch_io_loop(channel, sender):
         if channel:
@@ -142,10 +137,7 @@ class Reporter(NullReporter):
         return sender
 
     def set_process(self, service_name, tags, max_length):
-        with self._process_lock:
-            self._process = thrift.make_process(
-                service_name=service_name, tags=tags, max_length=max_length,
-            )
+        self._sender.set_process(service_name, tags, max_length)
 
     def report_span(self, span):
         # We should not be calling `queue.put_nowait()` from random threads,
@@ -168,14 +160,15 @@ class Reporter(NullReporter):
 
     @tornado.gen.coroutine
     def _consume_queue(self):
-        spans = []
+        spans_appended = 0
         stopped = False
+
         while not stopped:
-            while len(spans) < self.batch_size:
+            while spans_appended < self.batch_size:
                 try:
                     # using timeout allows periodic flush with smaller packet
                     timeout = self.flush_interval + self.io_loop.time() \
-                        if self.flush_interval and spans else None
+                        if self.flush_interval and spans_appended else None
                     span = yield self.queue.get(timeout=timeout)
                 except tornado.gen.TimeoutError:
                     break
@@ -186,43 +179,21 @@ class Reporter(NullReporter):
                         # don't return yet, submit accumulated spans first
                         break
                     else:
-                        spans.append(span)
-            if spans:
-                yield self._submit(spans)
-                for _ in spans:
+                        self._sender.append(span)
+                        spans_appended += 1
+
+            if spans_appended:
+                num_spans, exc, error_msg = yield self._sender.flush()
+                spans_appended = 0
+                if exc:
+                    self.metrics.reporter_failure(num_spans)
+                    self.error_reporter.error(error_msg, exc)
+                else:
+                    self.metrics.reporter_success(num_spans)
+                for _ in range(num_spans):
                     self.queue.task_done()
-                spans = spans[:0]
             self.metrics.reporter_queue_length(self.queue.qsize())
         self.logger.info('Span publisher exited')
-
-    @tornado.gen.coroutine
-    def _submit(self, spans):
-        if not spans:
-            return
-        with self._process_lock:
-            process = self._process
-            if not process:
-                return
-        try:
-            batch = thrift.make_jaeger_batch(spans=spans, process=process)
-            yield self._send(batch)
-            self.metrics.reporter_success(len(spans))
-        except socket.error as e:
-            self.metrics.reporter_failure(len(spans))
-            self.error_reporter.error(
-                'Failed to submit traces to jaeger-agent socket: %s', e)
-        except Exception as e:
-            self.metrics.reporter_failure(len(spans))
-            self.error_reporter.error(
-                'Failed to submit traces to jaeger-agent: %s', e)
-
-    @tornado.gen.coroutine
-    def _send(self, batch):
-        """
-        Send batch of spans out via thrift transport. Any exceptions thrown
-        will be caught above in the exception handler of _submit().
-        """
-        return self._sender.send(batch)
 
     def close(self):
         """

--- a/tests/test_senders.py
+++ b/tests/test_senders.py
@@ -13,22 +13,102 @@
 # limitations under the License.
 from __future__ import print_function
 
+import time
+import collections
 
 import mock
+import pytest
 from tornado import ioloop
+from tornado import gen
+from tornado.testing import AsyncTestCase, gen_test
 
 from jaeger_client import senders
+from jaeger_client import Span, SpanContext
 from jaeger_client.local_agent_net import LocalAgentSender
 from jaeger_client.thrift_gen.agent import Agent
+from jaeger_client.thrift_gen.jaeger import ttypes
 from thrift.protocol import TCompactProtocol
 
 
 def test_base_sender_create_io_loop_if_not_provided():
 
-    sender = senders.Sender(host='mock', port=4242)
+    sender = senders.Sender()
 
     assert sender.io_loop is not None
     assert isinstance(sender.io_loop, ioloop.IOLoop)
+
+
+def test_base_sender_send_not_implemented():
+    sender = senders.Sender()
+    with pytest.raises(NotImplementedError):
+        sender.send(1).result()
+
+
+def test_base_sender_set_process_instantiate_jaeger_process():
+    sender = senders.Sender()
+    sender.set_process('service', {}, max_length=0)
+    assert isinstance(sender._process, ttypes.Process)
+    assert sender._process.serviceName == 'service'
+
+
+def test_base_sender_spanless_flush_is_noop():
+    sender = senders.Sender()
+    flushed = sender.flush().result()
+    assert flushed is None
+
+    
+def test_base_sender_processless_flush_is_noop():
+    sender = senders.Sender()
+    sender.spans.append('foo')
+    flushed = sender.flush().result()
+    assert flushed is None
+
+
+class CustomException(Exception):
+    pass
+
+
+class SenderFlushTest(AsyncTestCase):
+    @gen_test
+    def test_base_sender_flush_yields_exceptions(self):
+        FakeTracer = collections.namedtuple('FakeTracer', ['ip_address', 'service_name'])
+        tracer = FakeTracer(ip_address='127.0.0.1', service_name='reporter_test')
+        sender = senders.Sender()
+        sender.set_process('service', {}, max_length=0)
+
+        ctx = SpanContext(trace_id=1, span_id=1, parent_id=None, flags=1)
+        span = Span(context=ctx, tracer=tracer, operation_name='foo')
+        span.start_time = time.time()
+        span.end_time = span.start_time + 0.001  # 1ms
+        sender.spans = [span]
+
+        sender.send = mock.MagicMock(side_effect=CustomException)
+        num_spans, exc, error_msg = yield sender.flush()
+        assert num_spans == 1
+        assert isinstance(exc, CustomException)
+        assert error_msg == 'Failed to send batch: %s'
+
+    @gen_test
+    def test_flush_batcher_accounting_information_yielded_from_flush(self):
+        @gen.coroutine
+        def stubbed_send(self, batch):
+            pass
+
+        @gen.coroutine
+        def stubbed__flush(self, spans, process):
+            raise gen.Return((100, CustomException(), 'SomeMessage'))
+
+        sender = senders.Sender()
+        sender.set_process('service', {}, max_length=0)
+        sender.spans = ['foo', 'bar']
+        sender._flush = stubbed__flush.__get__(sender)
+        sender.send = stubbed_send.__get__(sender)
+
+        num_spans, exc, error_msg = yield sender.flush()
+        assert num_spans == 100
+        assert isinstance(exc, CustomException)
+        assert error_msg == 'SomeMessage'
+
 
 def test_udp_sender_instantiate_thrift_agent():
 
@@ -46,7 +126,8 @@ def test_udp_sender_intantiate_local_agent_channel():
     assert sender.channel.io_loop == sender.io_loop
     assert isinstance(sender.channel, LocalAgentSender)
 
-def test_udp_sender_calls_agent_emitBatch_on_sending():
+
+def test_udp_sender_calls_agent_emitBatch_on_send():
 
     test_data = {'foo': 'bar'}
     sender = senders.UDPSender(host='mock', port=4242)


### PR DESCRIPTION
Implements the `Sender.append()` and `Sender.flush()` methods requested in https://github.com/jaegertracing/jaeger-client-python/pull/186#pullrequestreview-125400053 in an attempt to get those changes sourced.

Signed-off-by: Ryan Fitzpatrick <rmfitzpatrick@signalfx.com>